### PR TITLE
Check where the PostgresqlVIP is

### DIFF
--- a/migrator.py
+++ b/migrator.py
@@ -82,6 +82,7 @@ def migrate_primary(node):
     cluster_cmd("resource migrate msPostgresql {}".format(node))
     wait_for_primary(node)
     print("{} Migrated to node {}".format(datetime.datetime.now(), node))
+    cluster_cmd("resource unmigrate msPostgresql")
 
 
 def running_on_pgbouncer_vip():


### PR DESCRIPTION
A better "who-is-the-current-primary" check is one that looks for the
node that has the PostgresqlVIP. This is due to PostgresqlVIP starting
only after a machine is elected primary and also to pgbouncer connecting
to this vip by default.
